### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/src/RekognitionHandler.dart
+++ b/lib/src/RekognitionHandler.dart
@@ -69,7 +69,7 @@ class RekognitionHandler {
 
       HttpClientResponse response = await request.close();
 
-      await for (String a in response.transform(utf8.decoder)) {
+      await for (String a in utf8.decoder.bind(response)) {
         builder.write(a);
       }
     } catch (e) {

--- a/lib/src/TranslateHandler.dart
+++ b/lib/src/TranslateHandler.dart
@@ -90,7 +90,7 @@ class TranslateHandler {
 
       HttpClientResponse response = await request.close();
 
-      await for (String a in response.transform(utf8.decoder)) {
+      await for (String a in utf8.decoder.bind(response)) {
         builder.write(a);
       }
     } catch (e) {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
